### PR TITLE
Add demo file

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,1 +1,1 @@
-save_memory = False
+save_memory = True

--- a/demo/demo-t2v.py
+++ b/demo/demo-t2v.py
@@ -45,7 +45,9 @@ def demo_t2v_with_pose():
     model = Model(device="cuda", dtype=torch.float16)
     params = {}
     # more options for low GPU memory usage
-    params.update({"resolution": 320})  # 512
+    params.update({"chunk_size": 2})  # 8
+    params.update({"merging_ratio": 1})  # 0
+    params.update({"resolution": 460})  # 512
 
     prompt = 'an astronaut dancing in outer space'
     motion_path = '__assets__/poses_skeleton_gifs/dance1_corr.mp4'
@@ -56,5 +58,25 @@ def demo_t2v_with_pose():
     )
 
 
+# Edge
+def demo_t2v_with_edge():
+    print(f'\n######', sys._getframe().f_code.co_name)
+    model = Model(device="cuda", dtype=torch.float16)
+    params = {"low_threshold": 100, "high_threshold": 200}
+    # more options for low GPU memory usage
+    params.update({"chunk_size": 4})  # 8
+    params.update({"merging_ratio": 0})  # 0
+    params.update({"resolution": 400})  # 512
+
+    prompt = 'oil painting of a deer, a high-quality, detailed, and professional photo'
+    # video_path = '__assets__/canny_videos_mp4/deer.mp4'
+    video_path = '__assets__/canny_videos_edge/deer.mp4'
+    out_path = f'./text2video_edge_guidance_{prompt}.mp4'
+    model.process_controlnet_canny(
+        video_path, prompt=prompt, save_path=out_path, **params
+    )
+
+
 # demo_t2v()
-demo_t2v_with_pose()
+# demo_t2v_with_pose()
+demo_t2v_with_edge()

--- a/demo/demo-t2v.py
+++ b/demo/demo-t2v.py
@@ -77,6 +77,27 @@ def demo_t2v_with_edge():
     )
 
 
+# Depth
+def demo_t2v_with_depth():
+    print(f'\n######', sys._getframe().f_code.co_name)
+    model = Model(device="cuda", dtype=torch.float16)
+    params = {}
+    # more options for low GPU memory usage
+    params.update({"chunk_size": 8})  # 8
+    params.update({"merging_ratio": 0})  # 0
+    # 320: bad quality
+    params.update({"resolution": 320})  # 512
+
+    prompt = 'oil painting of a deer, a high-quality, detailed, and professional photo'
+    # video_path = '__assets__/depth_videos/deer.mp4'
+    video_path = '__assets__/depth_videos/fox.mp4'
+    out_path = f'./text2video_depth_control_{prompt}.mp4'
+    model.process_controlnet_depth(
+        video_path, prompt=prompt, save_path=out_path, **params
+    )
+
+
 # demo_t2v()
 # demo_t2v_with_pose()
-demo_t2v_with_edge()
+# demo_t2v_with_edge()
+demo_t2v_with_depth()

--- a/demo/demo-t2v.py
+++ b/demo/demo-t2v.py
@@ -2,25 +2,59 @@ import os
 import sys
 import torch
 from pathlib import Path
-sys.path.append(str(Path(__file__).absolute().parent.parent))
-os.environ['CURL_CA_BUNDLE'] = ''
 
+sys.path.append(str(Path(__file__).absolute().parent.parent))
+# os.environ['CURL_CA_BUNDLE'] = ''
 from model import Model
 
-model = Model(device = "cuda", dtype = torch.float16)
-#model = Model(device = "cpu", dtype = torch.float32)
-print(f'--> model {model}')
 
-prompt = "A horse galloping on a street"
-params = {"t0": 44, "t1": 47 , "motion_field_strength_x" : 12, "motion_field_strength_y" : 12, "video_length": 8}
-# more options
-params.update({"chunk_size" : 1})
-params.update({"merging_ratio" : 1})
-print(f'params: {params}')
+def prepare_model_list():
+    from hf_utils import get_model_list
 
-#out_path, fps = f"./text2video_{prompt.replace(' ','_')}.mp4", 4
-#model.process_text2video(prompt, fps = fps, path = out_path, **params)
+    model_list = get_model_list()
+    for idx, name in enumerate(model_list):
+        print(idx, name)
+    idx = int(
+        input("Select the model by the listed number: ")
+    )  # select the model of your choice
 
-motion_path = '__assets__/poses_skeleton_gifs/dance1_corr.mp4'
-out_path = f"./text2video_pose_guidance_{prompt.replace(' ','_')}.gif"
-model.process_controlnet_pose(motion_path, prompt=prompt, save_path=out_path)
+
+def demo_t2v():
+    print(f'\n######', sys._getframe().f_code.co_name)
+    model = Model(device="cuda", dtype=torch.float16)
+
+    prompt = "A horse galloping on a raining street"
+    params = {
+        "t0": 44,
+        "t1": 47,
+        "motion_field_strength_x": 12,
+        "motion_field_strength_y": 12,
+        "video_length": 8,
+    }
+    # more options for low GPU memory usage
+    params.update({"chunk_size": 2})  # 8
+    params.update({"merging_ratio": 1})  # 0
+
+    out_path, fps = f"./text2video_{prompt.replace(' ','_')}.mp4", 4
+    model.process_text2video(prompt, fps=fps, path=out_path, **params)
+
+
+# Pose
+def demo_t2v_with_pose():
+    print(f'\n######', sys._getframe().f_code.co_name)
+    model = Model(device="cuda", dtype=torch.float16)
+    params = {}
+    # more options for low GPU memory usage
+    params.update({"resolution": 320})  # 512
+
+    prompt = 'an astronaut dancing in outer space'
+    motion_path = '__assets__/poses_skeleton_gifs/dance1_corr.mp4'
+    # out_path = f"./text2video_pose_guidance_{prompt.replace(' ','_')}.gif"
+    out_path = f"./text2video_pose_guidance_{prompt.replace(' ','_')}.mp4"
+    model.process_controlnet_pose(
+        motion_path, prompt=prompt, save_path=out_path, **params
+    )
+
+
+# demo_t2v()
+demo_t2v_with_pose()

--- a/demo/demo-t2v.py
+++ b/demo/demo-t2v.py
@@ -3,8 +3,6 @@ import sys
 import torch
 from pathlib import Path
 sys.path.append(str(Path(__file__).absolute().parent.parent))
-
-
 os.environ['CURL_CA_BUNDLE'] = ''
 
 from model import Model
@@ -16,9 +14,13 @@ print(f'--> model {model}')
 prompt = "A horse galloping on a street"
 params = {"t0": 44, "t1": 47 , "motion_field_strength_x" : 12, "motion_field_strength_y" : 12, "video_length": 8}
 # more options
-params.update({"chunk_size" : 2})
+params.update({"chunk_size" : 1})
 params.update({"merging_ratio" : 1})
 print(f'params: {params}')
 
-out_path, fps = f"./text2video_{prompt.replace(' ','_')}.mp4", 4
-model.process_text2video(prompt, fps = fps, path = out_path, **params)
+#out_path, fps = f"./text2video_{prompt.replace(' ','_')}.mp4", 4
+#model.process_text2video(prompt, fps = fps, path = out_path, **params)
+
+motion_path = '__assets__/poses_skeleton_gifs/dance1_corr.mp4'
+out_path = f"./text2video_pose_guidance_{prompt.replace(' ','_')}.gif"
+model.process_controlnet_pose(motion_path, prompt=prompt, save_path=out_path)

--- a/demo/demo-t2v.py
+++ b/demo/demo-t2v.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import torch
+from pathlib import Path
+sys.path.append(str(Path(__file__).absolute().parent.parent))
+
+
+os.environ['CURL_CA_BUNDLE'] = ''
+
+from model import Model
+
+model = Model(device = "cuda", dtype = torch.float16)
+#model = Model(device = "cpu", dtype = torch.float32)
+print(f'--> model {model}')
+
+prompt = "A horse galloping on a street"
+params = {"t0": 44, "t1": 47 , "motion_field_strength_x" : 12, "motion_field_strength_y" : 12, "video_length": 8}
+# more options
+params.update({"chunk_size" : 2})
+params.update({"merging_ratio" : 1})
+print(f'params: {params}')
+
+out_path, fps = f"./text2video_{prompt.replace(' ','_')}.mp4", 4
+model.process_text2video(prompt, fps = fps, path = out_path, **params)

--- a/demo/demo-t2v.py
+++ b/demo/demo-t2v.py
@@ -77,6 +77,30 @@ def demo_t2v_with_edge():
     )
 
 
+# Edge, DreamBooth
+def demo_t2v_with_edge_dreambooth():
+    print(f'\n######', sys._getframe().f_code.co_name)
+    model = Model(device="cuda", dtype=torch.float16)
+    params = {"low_threshold": 100, "high_threshold": 200}
+    # more options for low GPU memory usage
+    params.update({"chunk_size": 4})  # 8
+    params.update({"merging_ratio": 0})  # 0
+    params.update({"resolution": 400})  # 512
+
+    prompt = 'avatar style'
+    video_path = 'woman1'
+    dreambooth_model_path = 'Avatar DB'
+    out_path = f'./text2video_edge_db_{prompt}.gif'
+
+    model.process_controlnet_canny_db(
+        dreambooth_model_path,
+        video_path,
+        prompt=prompt,
+        save_path=out_path,
+        **params,
+    )
+
+
 # Depth
 def demo_t2v_with_depth():
     print(f'\n######', sys._getframe().f_code.co_name)
@@ -100,4 +124,5 @@ def demo_t2v_with_depth():
 # demo_t2v()
 # demo_t2v_with_pose()
 # demo_t2v_with_edge()
-demo_t2v_with_depth()
+demo_t2v_with_edge_dreambooth()
+# demo_t2v_with_depth()

--- a/demo/demo-t2v.py
+++ b/demo/demo-t2v.py
@@ -121,8 +121,28 @@ def demo_t2v_with_depth():
     )
 
 
+# Video Instruct-Pix2Pix
+def demo_t2v_instruct_pix2pix():
+    print(f'\n######', sys._getframe().f_code.co_name)
+    model = Model(device="cuda", dtype=torch.float16)
+    params = {}
+    # more options for low GPU memory usage
+    params.update({"chunk_size": 4})  # 8
+    params.update({"merging_ratio": 0})  # 0
+    # 320: bad quality
+    params.update({"resolution": 360})  # 512
+
+    prompt = 'make it Van Gogh Starry Night'
+    video_path = '__assets__/pix2pix video/camel.mp4'
+    out_path = f'./video_instruct_pix2pix_{prompt}.mp4'
+    model.process_pix2pix(
+        video_path, prompt=prompt, save_path=out_path, **params
+    )
+
+
 # demo_t2v()
 # demo_t2v_with_pose()
 # demo_t2v_with_edge()
-demo_t2v_with_edge_dreambooth()
+# demo_t2v_with_edge_dreambooth()
 # demo_t2v_with_depth()
+demo_t2v_instruct_pix2pix()


### PR DESCRIPTION
### demo

- Device
NVIDIA GeForce RTX 3080, **10 GB** GPU Memory

-  Text-To-Video demo
Set `chunk_size` to 2, `merging_ratio` to 1.0, and the text-2-video model can be run with RTX 3080.

-  Text-To-Video with Pose Control demo
Failed to run Text-To-Video with Pose Control demo on RTX 3080, even set `chunk_size` to 1, `merging_ratio` to 1.0 and `save_memory` to True in config.py.
```
OutOfMemoryError: CUDA out of memory. Tried to allocate 4.00 GiB (GPU 0; 9.77 GiB total capacity; 3.90 GiB already allocated; 2.71 GiB free; 5.21 GiB reserved in total by PyTorch) If reserved memory is >> 
allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```